### PR TITLE
Fix tomcat source

### DIFF
--- a/libreoffice/Dockerfile
+++ b/libreoffice/Dockerfile
@@ -1,6 +1,6 @@
 FROM marsbard/base
-
-RUN apt-get update && apt-get -y --no-install-recommends install libreoffice supervisor
+RUN add-apt-repository -y ppa:libreoffice/ppa
+RUN apt-get update && apt-get -y --no-install-recommends install libreoffice supervisor libxinerama1 libdbus-glib-1-2
 
 RUN mkdir -p /var/log/supervisor 
 ADD files/supervisor.conf /etc/supervisor/conf.d/supervisor.conf 

--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -18,11 +18,12 @@ ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 
 
 ENV TOMCAT_MAJOR_VERSION 7
-ENV TOMCAT_MINOR_VERSION 7.0.65
-
+ENV TOMCAT_MINOR_VERSION 7.0.68
+# http://mirror.vorboss.net/apache/tomcat/tomcat-7/v7.0.68/bin/apache-tomcat-7.0.68.tar.gz
+# https://www.apache.org/dist/tomcat/tomcat-7/v7.0.68/bin/apache-tomcat-7.0.68.tar.gz.md5
 # INSTALL TOMCAT
-RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_MINOR_VERSION}/bin/apache-tomcat-${TOMCAT_MINOR_VERSION}.tar.gz && \
-    wget -qO- https://archive.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_MINOR_VERSION}/bin/apache-tomcat-${TOMCAT_MINOR_VERSION}.tar.gz.md5 | md5sum -c - && \
+RUN wget -q http://mirror.vorboss.net/apache/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_MINOR_VERSION}/bin/apache-tomcat-${TOMCAT_MINOR_VERSION}.tar.gz && \
+    wget -qO- https://www.apache.org/dist/tomcat/tomcat-${TOMCAT_MAJOR_VERSION}/v${TOMCAT_MINOR_VERSION}/bin/apache-tomcat-${TOMCAT_MINOR_VERSION}.tar.gz.md5 | md5sum -c - && \
     tar zxf apache-tomcat-*.tar.gz && \
     rm apache-tomcat-*.tar.gz && \
     mv apache-tomcat* tomcat 


### PR DESCRIPTION
the source for tomcat is offline 

This service is currently undergoing maintenance!

We are in the process of relocating this service. To save on the immense bandwidth that this service outputs, we have put it in maintenance mode, disabling all downloads for the next few days. We expect the maintenance to be complete no later than the morning of Monday the 11th of April, 2016.

have amended path to use mirror, which should be always available, and have bumped tomcat up to latest 7 release.
